### PR TITLE
Added half-open capability to check for downstream recovery using a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ fabric.properties
 **/*.sln.DotSettings.user
 
 cdk.out/
+.cdk.staging
 
 /lambdas/*
 .aws-sam/

--- a/cdk-circuit-breaker/cdk.json
+++ b/cdk-circuit-breaker/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "dotnet run -p src/CdkCircuitBreaker/CdkCircuitBreaker.csproj",
+  "app": "dotnet run --project src/CdkCircuitBreaker/CdkCircuitBreaker.csproj",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "aws-cdk:enableDiffNoFail": true,

--- a/cdk-circuit-breaker/src/CdkCircuitBreaker/CdkCircuitBreaker.csproj
+++ b/cdk-circuit-breaker/src/CdkCircuitBreaker/CdkCircuitBreaker.csproj
@@ -9,7 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.72.1" />
+    <!-- CDK Construct Library dependencies -->
+    <PackageReference Include="Amazon.CDK.Lib" Version="2.79.1" />
+    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+
+    <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
+    <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
+    -->
   </ItemGroup>
 
 </Project>

--- a/cdk-circuit-breaker/src/CdkCircuitBreaker/CdkCircuitBreakerStack.cs
+++ b/cdk-circuit-breaker/src/CdkCircuitBreaker/CdkCircuitBreakerStack.cs
@@ -1,3 +1,17 @@
+/**************************************************************************************************
+Legal Disclaimer: The sample code; software libraries; command line tools; proofs of concept;
+templates; or other related technology (including any of the foregoing that are provided by our
+personnel) is provided to you as AWS Content under the AWS Customer Agreement, or the relevant
+written agreement between you and AWS (whichever applies). You should not use this AWS Content in
+your production accounts, or on production or other critical data. You are responsible for testing,
+securing, and optimizing the AWS Content, such as sample code, as appropriate for production grade
+use based on your specific quality control practices and standards. Deploying AWS Content may incur
+AWS charges for creating or using AWS chargeable resources, such as running Amazon EC2 instances or
+using Amazon S3 storage.
+**************************************************************************************************/
+#define INCLUDE_TEST_FUNCTIONS
+
+using Constructs;                   // for Construct class
 using System.Collections.Generic;
 using Amazon.CDK;
 using Amazon.CDK.AWS.DynamoDB;
@@ -5,7 +19,7 @@ using Amazon.CDK.AWS.IAM;
 using Amazon.CDK.AWS.Lambda;
 using Amazon.CDK.AWS.StepFunctions;
 using Amazon.CDK.AWS.StepFunctions.Tasks;
-using Constructs;
+using Amazon.CDK.AWS.Logs;
 
 namespace CdkCircuitBreaker
 {
@@ -13,31 +27,8 @@ namespace CdkCircuitBreaker
     {
         internal CdkCircuitBreakerStack(Construct scope, string id, IStackProps props = null) : base(scope, id, props)
         {
-            #region iamroles
-            var iamLambdaRole = new Role(this,"LambdaExecutionRole", new RoleProps
-            {
-                RoleName = "LambdaExecutionRole",
-                AssumedBy = new ServicePrincipal("lambda.amazonaws.com")
-            });
-            
-            iamLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AmazonDynamoDBFullAccess"));
-            iamLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("CloudWatchLogsFullAccess"));
-            iamLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayFullAccess"));
-            iamLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSStepFunctionsFullAccess"));
-
-            var iamStepFunctionRole = new Role(this,"step_functions_basic_execution", new RoleProps
-            {
-                RoleName = "step_functions_basic_execution",
-                AssumedBy = new ServicePrincipal("states.amazonaws.com")
-            });
-            
-            iamStepFunctionRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("CloudWatchLogsFullAccess"));
-            iamStepFunctionRole.AddManagedPolicy(ManagedPolicy.FromManagedPolicyArn(this,"AWSLambdaRole","arn:aws:iam::aws:policy/service-role/AWSLambdaRole"));
-            iamStepFunctionRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayFullAccess"));
-            #endregion iamroles
-            
             #region DynamoDB tables
-            
+          
             var circuitBreakerTable = new Table(this, "CircuitBreaker", new TableProps
             {
                 TableName = "CircuitBreaker",
@@ -48,7 +39,7 @@ namespace CdkCircuitBreaker
                 },
                 SortKey = new Attribute
                 {
-                  Name  = "ExpireTimeStamp",
+                  Name  = "HiResTimeStamp",
                   Type = AttributeType.NUMBER
                 },
                 TimeToLiveAttribute = "ExpireTimeStamp",
@@ -59,113 +50,278 @@ namespace CdkCircuitBreaker
             
             #endregion
             
-            #region Lambda Functions
-
-            var getCircuitStatusLambda = new Function(this,"GetCircuitStatus", new FunctionProps
+            #region iamroles
+            var iamGetCircuitStatusLambdaRole = new Role(this,"GetCircuitStatusLambdaExecutionRole", new RoleProps
             {
-                FunctionName = "GetCircuitStatus",
-                Runtime = Runtime.DOTNET_6,
-                Handler = "GetCircuitStatusLambda::GetCircuitStatusLambda.GetCircuitStatus::FunctionHandler",
-                Role = iamLambdaRole,
-                Code = Code.FromAsset("lambdas/GetCircuitStatusLambda.zip"),
-                Timeout = Duration.Seconds(300)
+                RoleName = "GetCircuitStatusLambdaExecutionRole",
+                AssumedBy = new ServicePrincipal("lambda.amazonaws.com")
             });
             
-            var updateCircuitStatusLambda = new Function(this,"UpdateCircuitStatus", new FunctionProps
+            circuitBreakerTable.GrantReadWriteData(iamGetCircuitStatusLambdaRole);
+            circuitBreakerTable.Grant(iamGetCircuitStatusLambdaRole, "dynamodb:DescribeTable");
+            iamGetCircuitStatusLambdaRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps {
+                Resources = new [] { "*" },
+                Actions = new [] {
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                },
+                Effect = Effect.ALLOW
+            }));
+            iamGetCircuitStatusLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayWriteOnlyAccess"));
+
+            var iamUpdateCircuitStatusLambdaRole = new Role(this,"UpdateCircuitStatusLambdaExecutionRole", new RoleProps
             {
-                FunctionName = "UpdateCircuitStatus",
-                Runtime = Runtime.DOTNET_6,
-                Handler = "UpdateCircuitStatusLambda::UpdateCircuitStatusLambda.UpdateCircuitStatus::FunctionHandler",
-                Role = iamLambdaRole,
-                Code = Code.FromAsset("lambdas/UpdateCircuitStatusLambda.zip"),
-                Timeout = Duration.Seconds(300)
+                RoleName = "UpdateCircuitStatusLambdaExecutionRole",
+                AssumedBy = new ServicePrincipal("lambda.amazonaws.com")
             });
+            
+            circuitBreakerTable.GrantReadWriteData(iamUpdateCircuitStatusLambdaRole);
+            circuitBreakerTable.Grant(iamUpdateCircuitStatusLambdaRole, "dynamodb:DescribeTable");
+            iamUpdateCircuitStatusLambdaRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps {
+                Resources = new [] { "*" },
+                Actions = new [] {
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                },
+                Effect = Effect.ALLOW
+            }));
+            iamUpdateCircuitStatusLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayWriteOnlyAccess"));
+
+            #if INCLUDE_TEST_FUNCTIONS
+                var iamHelloWorldLambdaRole = new Role(this,"HelloWorldLambdaExecutionRole", new RoleProps
+                {
+                    RoleName = "HelloWorldLambdaExecutionRole",
+                    AssumedBy = new ServicePrincipal("lambda.amazonaws.com")
+                });
+                iamHelloWorldLambdaRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps {
+                    Resources = new [] { "*" },
+                    Actions = new [] {
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                    },
+                    Effect = Effect.ALLOW
+                }));
+                iamHelloWorldLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayWriteOnlyAccess"));
+
+                var iamTestCircuitBreakerLambdaRole = new Role(this,"TestCircuitBreakerLambdaExecutionRole", new RoleProps
+                {
+                    RoleName = "TestCircuitBreakerLambdaExecutionRole",
+                    AssumedBy = new ServicePrincipal("lambda.amazonaws.com")
+                });
+                iamTestCircuitBreakerLambdaRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps {
+                    Resources = new [] { "*" },
+                    Actions = new [] {
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                    },
+                    Effect = Effect.ALLOW
+                }));
+                iamTestCircuitBreakerLambdaRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayWriteOnlyAccess"));
+            #endif
+
+            var iamStepFunctionRole = new Role(this,"step_functions_basic_execution", new RoleProps
+            {
+                RoleName = "step_functions_basic_execution",
+                AssumedBy = new ServicePrincipal("states.amazonaws.com")
+            });
+            
+            iamStepFunctionRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps {
+                Resources = new [] { "*" },
+                Actions = new [] {
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                },
+                Effect = Effect.ALLOW
+            }));
+            iamStepFunctionRole.AddManagedPolicy(ManagedPolicy.FromAwsManagedPolicyName("AWSXrayWriteOnlyAccess"));
+            #endregion iamroles
+            
+            #region Lambda Functions
+
+            var getCircuitStatusLambda = new Function(this,"GetCircuitStatusFunction", new FunctionProps
+            {
+                Runtime = Runtime.DOTNET_6,
+                MemorySize = 256,
+                Handler = "GetCircuitStatusLambda::GetCircuitStatusLambda.GetCircuitStatus::FunctionHandler",
+                Role = iamGetCircuitStatusLambdaRole,
+                Code = Code.FromAsset("lambdas/GetCircuitStatusLambda.zip"),
+                Timeout = Duration.Seconds(30)
+            });
+            
+            var updateCircuitStatusLambda = new Function(this,"UpdateCircuitStatusFunction", new FunctionProps
+            {
+                Runtime = Runtime.DOTNET_6,
+                MemorySize = 256,
+                Handler = "UpdateCircuitStatusLambda::UpdateCircuitStatusLambda.UpdateCircuitStatus::FunctionHandler",
+                Role = iamUpdateCircuitStatusLambdaRole,
+                Code = Code.FromAsset("lambdas/UpdateCircuitStatusLambda.zip"),
+                Timeout = Duration.Seconds(30)
+            });
+            
+            #if INCLUDE_TEST_FUNCTIONS
+                var helloWorldLambda = new Function(this,"HelloWorldFunction", new FunctionProps
+                {
+                    Runtime = Runtime.DOTNET_6,
+                    MemorySize = 256,
+                    Handler = "HelloWorld::HelloWorld.Function::FunctionHandler",
+                    Role = iamHelloWorldLambdaRole,
+                    Code = Code.FromAsset("lambdas/HelloWorld.zip"),
+                    Timeout = Duration.Seconds(30)
+                });
+                
+                var testCircuitBreakerLambda = new Function(this,"TestCircuitBreakerFunction", new FunctionProps
+                {
+                    Runtime = Runtime.DOTNET_6,
+                    MemorySize = 256,
+                    Handler = "TestCircuitBreaker::TestCircuitBreaker.Function::FunctionHandler",
+                    Role = iamTestCircuitBreakerLambdaRole,
+                    Code = Code.FromAsset("lambdas/TestCircuitBreaker.zip"),
+                    Timeout = Duration.Seconds(30)
+                });
+            #endif
+
+            // Add code similar to that inside this #if to grant the State Machine permission to
+            //  invoke the TargetLambda(s) for the protected services.
+            #if INCLUDE_TEST_FUNCTIONS
+                iamStepFunctionRole.AddToPolicy(new PolicyStatement(new PolicyStatementProps {
+                    Resources = new [] {
+                        helloWorldLambda.FunctionArn,
+                        testCircuitBreakerLambda.FunctionArn
+                    },
+                    Actions = new [] {
+                        "lambda:InvokeFunction"
+                    },
+                    Effect = Effect.ALLOW
+                }));
+            #endif
             
             #endregion
             
             #region stepfunction
-             
-            var circuitClosed = new Succeed(this,"Circuit Closed");
-            var circuitOpen = new Fail(this, "Circuit Open");
+        
+            var Success = new Succeed(this,"Success", new SucceedProps
+            {
+                OutputPath = "$.Payload"
+            });
+
+            var Fail = new Fail(this, "Fail");
             
             var getCircuitStatusTask = new LambdaInvoke(this, "Get Circuit Status", new LambdaInvokeProps
             {
                 LambdaFunction = getCircuitStatusLambda,
                 Comment = "Get Circuit Status",
-                RetryOnServiceExceptions = false,
-                PayloadResponseOnly = true
+                ResultSelector = new Dictionary<string, object> {
+                    {"CircuitStatus.$", "$.Payload.CircuitControl.CircuitStatus"},
+                    {"HiResTimeStamp.$", "$.Payload.CircuitControl.HiResTimeStamp"},
+                    {"Count.$", "$.Payload.CircuitControl.Count"},
+                    {"MaxAttempts.$", "$.Payload.CircuitControl.MaxAttempts"},
+                    {"MaxConsecutive.$", "$.Payload.CircuitControl.MaxConsecutive"},
+                    {"MaxHalfRate.$", "$.Payload.CircuitControl.MaxHalfRate"},
+                    {"HalfIntervalSeconds.$", "$.Payload.CircuitControl.HalfIntervalSeconds"},
+                    {"InactivityResetSeconds.$", "$.Payload.CircuitControl.InactivityResetSeconds"},
+                    {"TimeoutSeconds.$", "$.Payload.CircuitControl.TimeoutSeconds"}
+                },
+                ResultPath = "$.CircuitControl",
+                Payload = TaskInput.FromJsonPathAt("$")
             });
-            
-            var updateCircuitStatusTask = new LambdaInvoke(this, "Update Circuit Status", new LambdaInvokeProps
+
+            var tryLimitReached = new Choice(this, "Try Limit Reached?")
+                .When(Condition.Or(
+                    Condition.IsNotPresent("$.CircuitControl.Count"),
+                    Condition.NumberGreaterThanEqualsJsonPath("$.CircuitControl.Count", "$.CircuitControl.MaxAttempts")
+                    ), Fail)
+                .Otherwise(getCircuitStatusTask);
+
+            var updateCircuitStatusTaskSuccess = new LambdaInvoke(this, "Record Invoke Success", new LambdaInvokeProps
             {
                 LambdaFunction = updateCircuitStatusLambda,
-                Comment = "Update Circuit Status",
-                RetryOnServiceExceptions = false,
-                PayloadResponseOnly = true
-            }).Next(circuitOpen);
-
+                Comment = "Update CallResult",
+                ResultPath = JsonPath.DISCARD,
+                Payload = TaskInput.FromJsonPathAt("$")
+            }).Next(Success);
+            
+            var updateCircuitStatusTaskFail = new LambdaInvoke(this, "Record Invoke Failure", new LambdaInvokeProps
+            {
+                LambdaFunction = updateCircuitStatusLambda,
+                Comment = "Update CallResult",
+                ResultSelector = new Dictionary<string, object> {
+                    {"CircuitStatus.$", "$.Payload.CircuitControl.CircuitStatus"},
+                    {"HiResTimeStamp.$", "$.Payload.CircuitControl.HiResTimeStamp"},
+                    {"Count.$", "$.Payload.CircuitControl.Count"},
+                    {"MaxAttempts.$", "$.Payload.CircuitControl.MaxAttempts"},
+                    {"MaxConsecutive.$", "$.Payload.CircuitControl.MaxConsecutive"},
+                    {"MaxHalfRate.$", "$.Payload.CircuitControl.MaxHalfRate"},
+                    {"HalfIntervalSeconds.$", "$.Payload.CircuitControl.HalfIntervalSeconds"},
+                    {"InactivityResetSeconds.$", "$.Payload.CircuitControl.InactivityResetSeconds"},
+                    {"TimeoutSeconds.$", "$.Payload.CircuitControl.TimeoutSeconds"}
+                },
+                ResultPath = "$.CircuitControl",
+                Payload = TaskInput.FromJsonPathAt("$")
+            }).Next(tryLimitReached);
+            
             var stateJson = new Dictionary<string, object>
             {
                 {"Type", "Task"},
-                {"Next", "Circuit Closed"},
+                {"Next", "Record Invoke Success"},
                 {"Resource", "arn:aws:states:::lambda:invoke"},
+                {"ResultPath", "$.Payload"},
                 {
                     "Parameters", new Dictionary<string, object>
                     {
+                        {"Payload.$", "$"},
                         {"FunctionName.$", "$.TargetLambda"}
                     }
                 },
-                {
-                    "Comment",
-                    "Task to execute lambda. This will set circuit status to OPEN if the execution fails for three times or the task times out"
-                },
-                {"TimeoutSeconds", 12},
-                {
-                    "Retry", new []
-                    {
-                        new Dictionary<string,object>()
-                        {
-                            {"BackoffRate", 1.5},
-                            {"MaxAttempts", 3},
-                            {"IntervalSeconds", 2},
-                            {"ErrorEquals", new string[] {Errors.TASKS_FAILED, Errors.TIMEOUT}}
-                        }
-                    }
-                },
+                {"Comment", "Task to execute lambda."},
+                {"TimeoutSecondsPath", "$.CircuitControl.TimeoutSeconds"},
                 {
                     "Catch", new []
                     {
                         new Dictionary<string, object>()
                         {
-                            {"ErrorEquals", new string[] {Errors.TASKS_FAILED, Errors.TIMEOUT}},
-                            {"Next", "Update Circuit Status"},
+                            {"ErrorEquals", new string[] 
+                                {
+                                    "States.TaskFailed",
+                                    "States.Timeout"
+                                }},
+                            {"Next", "Record Invoke Failure"},
                             {"ResultPath", "$.taskresult"}
                         }
                     }
                 }
             };
-            
             var executeLambdaTask = new CustomState(this, "Execute Lambda", new CustomStateProps
             {
                 StateJson = stateJson
-                
-            });
+            }).Next(updateCircuitStatusTaskSuccess);
 
             var stepDefinition = Chain.Start(getCircuitStatusTask)
-                .Next(new Choice(this, "Is Circuit Closed")
-                    .When(Condition.StringEquals("$.CircuitStatus", "OPEN"), circuitOpen)
-                    .When(Condition.StringEquals("$.CircuitStatus", ""), executeLambdaTask.Next(circuitClosed)));
+                .Next(new Choice(this, "Is Circuit Open?")
+                    .When(Condition.StringEquals("$.CircuitControl.CircuitStatus", "OPEN"), Fail)
+                    .Otherwise(executeLambdaTask)
+                );
+
+            LogGroup logGroup = new LogGroup(this, "CircutBreakerLogGroup");
          
             var stateMachine = new StateMachine(this, "CircuitBreaker-StepFunction", new StateMachineProps {
                 StateMachineName = "CircuitBreaker-StepFunction",
-                StateMachineType = StateMachineType.STANDARD,
+                StateMachineType = StateMachineType.EXPRESS,
                 Role = iamStepFunctionRole,
                 TracingEnabled = true,
-                Definition = stepDefinition
+                Definition = stepDefinition,
+                Logs = new LogOptions {
+                    Destination = logGroup,
+                    Level = LogLevel.ALL,
+                    IncludeExecutionData = true
+                }
             });
             
             #endregion
         }
     }
 }
-

--- a/circuit-breaker/GetCircuitStatusLambda/src/GetCircuitStatusLambda/Function.cs
+++ b/circuit-breaker/GetCircuitStatusLambda/src/GetCircuitStatusLambda/Function.cs
@@ -1,3 +1,15 @@
+/**************************************************************************************************
+Legal Disclaimer: The sample code; software libraries; command line tools; proofs of concept;
+templates; or other related technology (including any of the foregoing that are provided by our
+personnel) is provided to you as AWS Content under the AWS Customer Agreement, or the relevant
+written agreement between you and AWS (whichever applies). You should not use this AWS Content in
+your production accounts, or on production or other critical data. You are responsible for testing,
+securing, and optimizing the AWS Content, such as sample code, as appropriate for production grade
+use based on your specific quality control practices and standards. Deploying AWS Content may incur
+AWS charges for creating or using AWS chargeable resources, such as running Amazon EC2 instances or
+using Amazon S3 storage.
+**************************************************************************************************/
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,7 +18,10 @@ using Amazon.Lambda.Core;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
-
+using Amazon.CloudWatch.EMF.Config;
+using Amazon.CloudWatch.EMF.Environment;
+using Amazon.CloudWatch.EMF.Logger;
+using Amazon.CloudWatch.EMF.Model;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -15,37 +30,313 @@ namespace GetCircuitStatusLambda
 {
     public class GetCircuitStatus
     {
+        private const int debugLevel = 0;
+
+        // ConsistentRead provides strongly consistent reads at the expense of higher latency and
+        //  increased capacity units. As the impact of inconsistency could only result in extra
+        //  traffic when throttling, the benefit is not viewed as worth the cost.
+        private const Boolean CONSISTENT_READ = false;
+        
+        // QUERY_PAGE_SIZE of 70 was selected for economy and efficiency as 70 records can be retrieved
+        //   for 0.5 LCU.  With 70 concurrent executions, there is the potential to not look back far
+        //   enough to find consecutive completed calls.  This is a design tradeoff against cost and
+        //   latency because retrieving another page of records would further delay execution.
+        private const int QUERY_PAGE_SIZE = 70;
+        private const string CIRCUIT_STATUS_CLOSED = "CLOSED";
+        private const string CIRCUIT_STATUS_HALF = "HALF";
+        private const string CIRCUIT_STATUS_OPEN = "OPEN";
+
+        // Default limit for attempts to loop through the Step Function to execute the Lambda function.
+        //  Note that a CircuitStatus of "OPEN" returned by this function overrides MaxAttempts by terminating the Step Function.
+        private const int DEF_MAX_ATTEMPTS = 3;
+
+        // Default number of consecutive Successes or Failures before transitioning CircuitStatus to CLOSED or HALF respectively.
+        private const int DEF_MAX_CONSECUTIVE = 3;
+
+        // Default number of execution attempts allowed per HalfIntervalSeconds
+        private const int DEF_MAX_HALF_RATE = 1;
+
+        // Default number of seconds in the throttling interval with CircuitStatus in HALF (Open/Closed).
+        //  Using default values as an example, 1 attempt is allowed if there have been no other attempts
+        //  in the last 30 seconds.  The value of 1 comes from DEF_MAX_HALF_RATE.
+        //  Note that records with a Success (1) CallResult are excluded from this query.
+        //    CallResult values of None (0) meaning in-progress and Fail (2) are counted.
+        private const int DEF_HALF_INTERVAL_SECONDS = 30;
+        
+        // Default number of seconds to retain CircuitBreaker DDB Table records.
+        //   With no records, CircuitStatus defaults to CLOSED.
+        //   InactivityResetSeconds is programmatically forced to be equal or greater than HalfIntervalSeconds.
+        private const int DEF_INACTIVITY_RESET_SECONDS = 300;
+
+        // Default number of seconds for Step Function State "Execute Lambda" to wait
+        //  for TargetLambda function to complete.
+        private const int DEF_TIMEOUT_SECONDS = 12;
+
         private static AmazonDynamoDBClient client = new AmazonDynamoDBClient();
-        private DynamoDBContext _dbContext = new DynamoDBContext(client,new DynamoDBContextConfig {ConsistentRead = true});
-        public FunctionData FunctionHandler(FunctionData functionData, ILambdaContext context)
+        private DynamoDBContext _dbContext = new DynamoDBContext(client,new DynamoDBContextConfig {ConsistentRead = CONSISTENT_READ});
+        
+        public async Task<FunctionData> FunctionHandler(FunctionData functionData, ILambdaContext context)
         {
             string serviceName = functionData.TargetLambda;
-            var currentTimeStamp = DateTimeOffset.Now.ToUnixTimeSeconds();
-            
+
+            if (functionData.CircuitControl is null)
+                functionData.CircuitControl = new CircuitControl_Fields();
+
+            functionData.CircuitControl.CircuitStatus = CIRCUIT_STATUS_CLOSED;
+
+            functionData.CircuitControl.Count++;
+
+            if (functionData.CircuitControl.MaxAttempts <= 0)
+                functionData.CircuitControl.MaxAttempts = DEF_MAX_ATTEMPTS;
+
+            if (functionData.CircuitControl.MaxConsecutive <= 0)
+                functionData.CircuitControl.MaxConsecutive = DEF_MAX_CONSECUTIVE;
+
+            if (functionData.CircuitControl.MaxHalfRate <= 0)
+                functionData.CircuitControl.MaxHalfRate = DEF_MAX_HALF_RATE;
+
+            if (functionData.CircuitControl.HalfIntervalSeconds <= 0)
+                functionData.CircuitControl.HalfIntervalSeconds = DEF_HALF_INTERVAL_SECONDS;
+
+            if (functionData.CircuitControl.InactivityResetSeconds <= 0)
+                functionData.CircuitControl.InactivityResetSeconds = DEF_INACTIVITY_RESET_SECONDS;
+
+            // Records must not expire before HalfIntervalSeconds
+            if (functionData.CircuitControl.HalfIntervalSeconds > functionData.CircuitControl.InactivityResetSeconds)
+                functionData.CircuitControl.InactivityResetSeconds = functionData.CircuitControl.HalfIntervalSeconds;
+
+            if (functionData.CircuitControl.TimeoutSeconds <= 0)
+                functionData.CircuitControl.TimeoutSeconds = DEF_TIMEOUT_SECONDS;
+
+            functionData.CircuitControl.HiResTimeStamp = DateTimeOffset.Now.AddSeconds(functionData.CircuitControl.InactivityResetSeconds).ToUnixTimeMilliseconds();
+
+        //
+        // Step 1.  Determine Status from existing records for this service
+        //
+
+            // Attempt to get status from newest (last) record with start time >= Now
+            // Records are sorted by the Query
+            var currentTimeStamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
             // Example of using scan when TTL attribute is not a sort key 
             // var scan1 = new ScanCondition("ServiceName",ScanOperator.Equal,serviceName);
-            // var scan2 = new ScanCondition("ExpireTimeStamp",ScanOperator.GreaterThan,currentTimeStamp);
+            // var scan2 = new ScanCondition("HiResTimeStamp",ScanOperator.GreaterThan,currentTimeStamp);
             // var serviceDetails = _dbContext.ScanAsync<CircuitBreaker>(new []{scan1, scan2}).GetRemainingAsync();
             
-            //Example of using query when TTL attribute is a sort key
+            DynamoDBOperationConfig opConfig = new DynamoDBOperationConfig();
+            opConfig.BackwardQuery = true;
+/*
+            //Example of using query when TTL attribute is a sort key to retrieve all records
             var serviceDetails = _dbContext.QueryAsync<CircuitBreaker>(serviceName, QueryOperator.GreaterThan,
                 new List<object>
-                    {currentTimeStamp}).GetRemainingAsync();
+                    {currentTimeStamp}, opConfig).GetRemainingAsync();
+*/
+            // queryOperationConfig used with FromQUeryAsync allows use of Limit to limit number of table records
+            // Retrieve QUERY_PAGE_SIZE records where HiResTimeStamp is greater than currentTimeStamp
+            //   The multipler is to account for in-progress calls which are not used for status change detection.
+            // Only the newest record is used in Step 1; however other records are used in Step 2.
+            var queryOperationConfig = new QueryOperationConfig();
+            queryOperationConfig.ConsistentRead = CONSISTENT_READ;
+            var keyExpression = new Expression();
+            keyExpression.ExpressionStatement = "ServiceName=:pk and HiResTimeStamp>:sk";
+            keyExpression.ExpressionAttributeValues = new Dictionary<string, DynamoDBEntry>();
+            keyExpression.ExpressionAttributeValues.Add(":pk", serviceName);
+            keyExpression.ExpressionAttributeValues.Add(":sk", currentTimeStamp);
+            queryOperationConfig.KeyExpression = keyExpression;
+            queryOperationConfig.Limit = QUERY_PAGE_SIZE;
+            queryOperationConfig.BackwardSearch = true;
 
-            foreach (var circuitBreaker in serviceDetails.Result)
+            try
             {
-                context.Logger.Log(circuitBreaker.ServiceName);
-                context.Logger.Log(circuitBreaker.ExpireTimeStamp.ToString());
+                var serviceDetails = _dbContext.FromQueryAsync<CircuitBreaker>(queryOperationConfig, opConfig).GetNextSetAsync();
+
+                if (debugLevel <= 1)
+                    context.Logger.Log(serviceName);
+
+                if (debugLevel == 0)
+                {
+                    context.Logger.Log("currentTimeStamp: " + currentTimeStamp);
+                    context.Logger.Log("current HiResTimeStamp: " + functionData.CircuitControl.HiResTimeStamp);
+
+                    context.Logger.Log("Call Records read in Step 1: " + serviceDetails.Result.Count.ToString());
+                }
+
+                if (serviceDetails.Result.Count > 0)
+                    functionData.CircuitControl.CircuitStatus = serviceDetails.Result[0].CircuitStatus;
+
+                if (debugLevel <= 1)
+                    context.Logger.Log("CircuitStatus from CircuitBreaker table: " + functionData.CircuitControl.CircuitStatus);
+
+                //
+                // Step 2.  Check for successive failures or successes to transition Circuit Status
+                //
+
+                int counter = 0;
+                int failCounter = 0;
+                int successCounter = 0;
+
+                foreach (var circuitBreaker in serviceDetails.Result)
+                {
+                    switch(circuitBreaker.CallResult)
+                    {
+                        case ResultTypes.Fail:
+                            ++counter;
+                            ++failCounter;
+                            if (debugLevel == 0)
+                            {                        
+                                context.Logger.Log("HiResTimeStamp: " + circuitBreaker.HiResTimeStamp.ToString());
+                                context.Logger.Log("CallResult: Fail");
+                            }
+                            break;
+                        case ResultTypes.Success:
+                            ++counter;
+                            ++successCounter;
+                            if (debugLevel == 0)
+                            {                        
+                                context.Logger.Log("HiResTimeStamp: " + circuitBreaker.HiResTimeStamp.ToString());
+                                context.Logger.Log("CallResult: Success");
+                            }
+                            break;
+                        default:
+                            // do nothing
+                            break;
+                    }
+
+                    if (counter >= functionData.CircuitControl.MaxConsecutive)
+                    {
+                        if (failCounter >= functionData.CircuitControl.MaxConsecutive)
+                        {
+                            if (functionData.CircuitControl.CircuitStatus == CIRCUIT_STATUS_CLOSED)
+                                functionData.CircuitControl.CircuitStatus = CIRCUIT_STATUS_HALF;
+                        }
+                        else if (successCounter >= functionData.CircuitControl.MaxConsecutive)
+                        {
+                            if (functionData.CircuitControl.CircuitStatus == CIRCUIT_STATUS_HALF)
+                                functionData.CircuitControl.CircuitStatus = CIRCUIT_STATUS_CLOSED;
+                        }
+                        //Check only the last functionData.CircuitControl.MaxConsecutive completed calls.
+                        break;
+                    }
+
+                }
+            }
+            catch (Exception ex)
+            {   // Error accessing Table;  TargetLambda call will be allowed
+                context.Logger.Log("Error Reading DDB Table for Steps 1,2: " + ex.Message);
+                functionData.CircuitControl.HiResTimeStamp = 0;  // Indicator that there is no DDB Table record to update
+                return functionData;
             }
 
-            if (serviceDetails.Result.Count > 0)
+            //
+            // Step 3.  For Half-Open/Closed case, check for number of records in the interval
+            // Note that Records are written with an offset equal to INACTIVITY RESET_SECONDS so
+            //   to get records for the interval, time must be adjusted accordingly.
+            //
+            if (functionData.CircuitControl.CircuitStatus == CIRCUIT_STATUS_HALF)
             {
-                functionData.CircuitStatus = serviceDetails.Result[0].CircuitStatus;
+                if (debugLevel <= 1)
+                    context.Logger.Log("Half-open mode.  Checking for throttling...");
+
+                // Query will retrieve records that do not have a CallResult of Success for requests starting 
+                //   within the last HALF_INTERVAL_SECONDS period of time.
+                var intervalTimeStamp = DateTimeOffset.Now.AddSeconds(functionData.CircuitControl.InactivityResetSeconds
+                   -functionData.CircuitControl.HalfIntervalSeconds).ToUnixTimeMilliseconds();
+
+                // Example of using scan when TTL attribute is not a sort key 
+                // var scan1 = new ScanCondition("ServiceName",ScanOperator.Equal,serviceName);
+                // var scan2 = new ScanCondition("HiResTimeStamp",ScanOperator.GreaterThan,currentTimeStamp);
+                // var serviceDetails = _dbContext.ScanAsync<CircuitBreaker>(new []{scan1, scan2}).GetRemainingAsync();
+
+                ScanCondition myFilter = new ScanCondition("CallResult", ScanOperator.NotEqual, ResultTypes.Success);
+                List<ScanCondition> scanList = new List<ScanCondition>();
+                scanList.Add(myFilter);
+                opConfig.QueryFilter = scanList;
+
+                try
+                {
+                    //Example of using query when TTL attribute is a sort key
+                    var serviceDetails = _dbContext.QueryAsync<CircuitBreaker>(serviceName, QueryOperator.GreaterThan,
+                        new List<object>
+                            {intervalTimeStamp}, opConfig).GetRemainingAsync();
+
+                    if (debugLevel == 0)
+                    {
+                        context.Logger.Log("Non-Success Records in last " + functionData.CircuitControl.HalfIntervalSeconds 
+                        + " seconds : " + serviceDetails.Result.Count.ToString());
+
+                        foreach (var circuitBreaker in serviceDetails.Result)
+                        {
+                            context.Logger.Log(circuitBreaker.ServiceName);
+                            context.Logger.Log(circuitBreaker.HiResTimeStamp.ToString());
+                        }
+                    }
+
+                    if (serviceDetails.Result.Count >= functionData.CircuitControl.MaxHalfRate)
+                        functionData.CircuitControl.CircuitStatus = CIRCUIT_STATUS_OPEN;
+                }
+                catch (Exception ex)
+                {
+                    context.Logger.Log("Error Reading DDB Table in Step 3: " + ex.Message);
+                    functionData.CircuitControl.HiResTimeStamp = 0;  // Indicator that there is no DDB Table record to update
+                    return functionData;   // Error accessing Table;  TargetLambda call will be allowed
+                }
             }
-            else
-            {
-                functionData.CircuitStatus = "";
+
+            //
+            // Step 4.  Write new start record
+            //
+
+            if (functionData.CircuitControl.CircuitStatus != CIRCUIT_STATUS_OPEN)
+            {   // Write new start record
+                try
+                {
+                    var circuitBreaker = new CircuitBreaker
+                    {
+                        ServiceName = serviceName,
+                        CircuitStatus = functionData.CircuitControl.CircuitStatus,
+                        HiResTimeStamp = functionData.CircuitControl.HiResTimeStamp,
+
+                        // DDB TTL must be in seconds; adding 1 second to account for truncation of sub-second time
+                        ExpireTimeStamp = (functionData.CircuitControl.HiResTimeStamp/1000) + 1
+                    };
+
+                    await _dbContext.SaveAsync(circuitBreaker);
+                }
+                catch (Exception ex)
+                {
+                    context.Logger.Log("Error Writing New DDB Record: " + ex.Message);
+                    functionData.CircuitControl.HiResTimeStamp = 0;  // Indicator that there is no DDB Table record to update
+                }
             }
+
+            if (debugLevel <= 1)
+                context.Logger.Log("CircuitStatus returned by function: " + functionData.CircuitControl.CircuitStatus);
+
+            // Provide CloudWatch Metric with CircuitStatus as Dimension
+            var envProvider = new EnvironmentProvider(EnvironmentConfigurationProvider.Config, new ResourceFetcher());
+            var logger = new MetricsLogger();
+            var dimensionSet = new DimensionSet();
+
+            dimensionSet.AddDimension("CircuitStatus", functionData.CircuitControl.CircuitStatus);
+            logger.SetDimensions(dimensionSet);
+            logger.SetNamespace("CircuitBreaker");
+            logger.PutMetric("CircuitBreakerUsage", 1, Unit.COUNT);
+            logger.Flush();
+
+            // Provide CloudWatch Metric with CircuitStatus and TargetLambda as Dimensions
+            // This metric includes ServiceName and ServiceType dimensions in order
+            //    to distinguist an instance of GetCircuitStatus in case of multiple regions.
+            //    Those dimensions are included by default with PutDimensions()
+            // Provide full Arn as Property and use only the Lambda function name as a Dimension
+            logger.PutProperty("TargetLambdaArn", serviceName);            
+            int position = serviceName.IndexOf(":function:");
+            if (position > 0)
+                serviceName = serviceName.Substring(position + 10);
+            dimensionSet.AddDimension("TargetLambda", serviceName);
+            logger.ResetDimensions(true);
+            logger.PutDimensions(dimensionSet);
+            logger.PutMetric("CircuitBreakerUsage", 1, Unit.COUNT);
+            logger.Flush();
 
             return functionData;
         }
@@ -56,17 +347,38 @@ namespace GetCircuitStatusLambda
     {
         [DynamoDBHashKey]
         public string ServiceName { get; set; }
-        [DynamoDBProperty]
-        public string CircuitStatus { get; set; }
-        
-        [DynamoDBRangeKey]
-        public long ExpireTimeStamp { get; set; }
-    }
 
+       [DynamoDBProperty]
+        public long ExpireTimeStamp { get; set; }
+        public string CircuitStatus { get; set; }
+        public ResultTypes CallResult { get; set; }
+
+        [DynamoDBRangeKey]
+        public long HiResTimeStamp { get; set; }
+    }
+    [Flags]
+    public enum ResultTypes
+    {
+        None = 0,
+        Success = 1,
+        Fail = 2,
+    }
 
     public class FunctionData
     {
         public string TargetLambda { get; set; }
+        public CircuitControl_Fields CircuitControl { get; set; }
+    }
+    public class CircuitControl_Fields
+    {
         public string CircuitStatus { get; set; }
+        public long HiResTimeStamp { get; set; }
+        public int Count { get; set; }
+        public int MaxAttempts { get; set; }
+        public int MaxConsecutive { get; set; }
+        public int MaxHalfRate { get; set; }
+        public int HalfIntervalSeconds { get; set; }
+        public int InactivityResetSeconds { get; set; }
+        public int TimeoutSeconds { get; set; }        
     }
 }

--- a/circuit-breaker/GetCircuitStatusLambda/src/GetCircuitStatusLambda/GetCircuitStatusLambda.csproj
+++ b/circuit-breaker/GetCircuitStatusLambda/src/GetCircuitStatusLambda/GetCircuitStatusLambda.csproj
@@ -9,5 +9,6 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.102.17" />
+	    <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.0.0"/>    
     </ItemGroup>
 </Project>

--- a/circuit-breaker/GetCircuitStatusLambda/src/GetCircuitStatusLambda/aws-lambda-tools-defaults.json
+++ b/circuit-breaker/GetCircuitStatusLambda/src/GetCircuitStatusLambda/aws-lambda-tools-defaults.json
@@ -7,10 +7,5 @@
   ],
   "profile": "",
   "region": "",
-  "configuration": "Release",
-  "framework": "net6.0",
-  "function-runtime": "dotnet6",
-  "function-memory-size": 256,
-  "function-timeout": 30,
-  "function-handler": "GetCircuitStatusLambda::GetCircuitStatusLambda.Function::FunctionHandler"
+  "configuration": "Release"
 }

--- a/circuit-breaker/HelloWorld/src/HelloWorld/Function.cs
+++ b/circuit-breaker/HelloWorld/src/HelloWorld/Function.cs
@@ -14,14 +14,24 @@ namespace HelloWorld
         public FunctionData FunctionHandler(FunctionData fnData, ILambdaContext context)
         {
             context.Logger.Log("Hello World from successful circuit");
+
+            if (fnData.taskresult is null)
+                fnData.taskresult = new TaskResultFields();
+
+            fnData.taskresult.Error = "";
             return fnData;
         }
     }
     
-    public class FunctionData
+   public class FunctionData
     {
-        public string TargetLambda { get; set; }
-        public string CircuitStatus { get; set; }
+        public TaskResultFields taskresult { get; set; }
         public string JsonPayload { get; set; }
+
     }
+    public class TaskResultFields
+    {
+        public string Error { get; set; }
+        public string Cause { get; set; }
+    }        
 }

--- a/circuit-breaker/TestCircuitBreaker/src/TestCircuitBreaker/Function.cs
+++ b/circuit-breaker/TestCircuitBreaker/src/TestCircuitBreaker/Function.cs
@@ -12,17 +12,24 @@ namespace TestCircuitBreaker
 {
     public class Function
     {
-        public FunctionData FunctionHandler(FunctionData fnData, ILambdaContext context)
+        public FunctionData FunctionHandler(FunctionData functionData, ILambdaContext context)
         {
-            Thread.Sleep(15000);
-            return fnData;
+            if (functionData.PassTest == 0)
+                Thread.Sleep(15000);
+            return functionData;
         }
     }
     
-    public class FunctionData
+       public class FunctionData
     {
-        public string TargetLambda { get; set; }
-        public string CircuitStatus { get; set; }
+        public long PassTest { get; set; }
+        public TaskResultFields taskresult { get; set; }
         public string JsonPayload { get; set; }
+
     }
+    public class TaskResultFields
+    {
+        public string Error { get; set; }
+        public string Cause { get; set; }
+    }        
 }

--- a/circuit-breaker/UpdateCircuitStatusLambda/src/UpdateCircuitStatusLambda/Function.cs
+++ b/circuit-breaker/UpdateCircuitStatusLambda/src/UpdateCircuitStatusLambda/Function.cs
@@ -1,11 +1,25 @@
+/**************************************************************************************************
+Legal Disclaimer: The sample code; software libraries; command line tools; proofs of concept;
+templates; or other related technology (including any of the foregoing that are provided by our
+personnel) is provided to you as AWS Content under the AWS Customer Agreement, or the relevant
+written agreement between you and AWS (whichever applies). You should not use this AWS Content in
+your production accounts, or on production or other critical data. You are responsible for testing,
+securing, and optimizing the AWS Content, such as sample code, as appropriate for production grade
+use based on your specific quality control practices and standards. Deploying AWS Content may incur
+AWS charges for creating or using AWS chargeable resources, such as running Amazon EC2 instances or
+using Amazon S3 storage.
+**************************************************************************************************/
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.Lambda.Core;
+using System.Linq;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2.DocumentModel;
-
+using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -14,68 +28,107 @@ namespace UpdateCircuitStatusLambda
 {
     public class UpdateCircuitStatus
     {
-        private const string CIRCUIT_STATUS = "OPEN";
-        private const int EXPIRE_SECONDS = 20;
         private static AmazonDynamoDBClient client = new AmazonDynamoDBClient();
-        private DynamoDBContext _dbContext = new DynamoDBContext(client, new DynamoDBContextConfig {ConsistentRead = true});
+        private static string tableName = "CircuitBreaker";
 
         public async Task<FunctionData> FunctionHandler(FunctionData functionData, ILambdaContext context)
         {
-            string serviceName = functionData.TargetLambda;
-            functionData.CircuitStatus = CIRCUIT_STATUS;
-            var currentTimeStamp = DateTimeOffset.Now.ToUnixTimeSeconds();
-            
-            //Example of using scan when TTL attribute is not a sort key 
-            // var scan1 = new ScanCondition("ServiceName",ScanOperator.Equal,serviceName);
-            // var scan2 = new ScanCondition("ExpireTimeStamp",ScanOperator.GreaterThan,currentTimeStamp);
-            // var serviceDetails = _dbContext.ScanAsync<CircuitBreaker>(new []{scan1, scan2}).GetRemainingAsync();
-            
-            //Example of using query when TTL attribute is a sort key
-            var serviceDetails = _dbContext.QueryAsync<CircuitBreaker>(serviceName, QueryOperator.GreaterThan,
-                new List<object>
-                    {currentTimeStamp}).GetRemainingAsync();
-            
-            context.Logger.Log(serviceDetails.Result.Count.ToString());
-            if (serviceDetails.Result.Count == 0)
+
+            // If GetCircuitStatus encounters an error accessing the CircuitBreaker Table,
+            //  there won't be a record to update.
+            if ((functionData.CircuitControl is null) ||
+                (functionData.CircuitControl.HiResTimeStamp == 0))
             {
-                context.Logger.Log("Inside save construct");
-                try
-                {
-                    // increase 20 seconds to a higher value as needed during test
-                    var circuitBreaker = new CircuitBreaker
-                    {
-                        ServiceName = serviceName,
-                        CircuitStatus = CIRCUIT_STATUS,
-                        ExpireTimeStamp = DateTimeOffset.Now.AddSeconds(EXPIRE_SECONDS).ToUnixTimeSeconds()
-                    };
-                    await _dbContext.SaveAsync(circuitBreaker);
-                }
-                catch (Exception ex)
-                {
-                    context.Logger.Log(ex.Message);
-                }
+                context.Logger.Log("CircuitControl.HiResTimeStamp is zero. Unable to update CallResult");
+                return functionData;
             }
-            
+
+            string serviceName = functionData.TargetLambda;
+
+            int callResult;
+            if (functionData.taskresult is null || functionData.taskresult.Error == "")
+                callResult = (int)ResultTypes.Success;
+            else
+                callResult = (int)ResultTypes.Fail;
+
+            // Define item key
+            //  Hash-key of the target item is string value functionData.TargetLambda (a.k.a. serviceName)
+            //  Range-key of the target item is string value functionData.HiResTimeStamp
+            Dictionary<string, AttributeValue> key = new Dictionary<string, AttributeValue>
+            {
+                { "ServiceName", new AttributeValue { S = serviceName } },
+                { "HiResTimeStamp", new AttributeValue { N = functionData.CircuitControl.HiResTimeStamp.ToString() } }
+            };
+
+            // Define attribute updates
+            Dictionary<string, AttributeValueUpdate> updates = new Dictionary<string, AttributeValueUpdate>();
+            // Update item's Setting attribute
+            updates["CallResult"] = new AttributeValueUpdate()
+            {
+                Action = AttributeAction.PUT,
+                Value = new AttributeValue { N = callResult.ToString() }
+            };
+
+            // Create UpdateItem request
+            UpdateItemRequest request = new UpdateItemRequest
+            {
+                TableName = tableName,
+                Key = key,
+                AttributeUpdates = updates
+            };
+
+            // Issue request
+            await client.UpdateItemAsync(request);
+
             return functionData;
         }
     }
     
+    
     [DynamoDBTable("CircuitBreaker")]
-    public class CircuitBreaker
+       public class CircuitBreaker
     {
         [DynamoDBHashKey]
         public string ServiceName { get; set; }
-        [DynamoDBProperty]
+
+       [DynamoDBProperty]
         public string CircuitStatus { get; set; }
-        
-        [DynamoDBRangeKey]
+        public ResultTypes CallResult { get; set; }
         public long ExpireTimeStamp { get; set; }
+
+        [DynamoDBRangeKey]
+        public long HiResTimeStamp { get; set; }
+    }
+    [Flags]
+    public enum ResultTypes
+    {
+        None      = 0,
+        Success = 1,
+        Fail = 2
     }
 
-
-    public class FunctionData
+   public class FunctionData
     {
         public string TargetLambda { get; set; }
-        public string CircuitStatus { get; set; }
+        public CircuitControl_Fields CircuitControl { get; set; }
+        public TaskResultFields taskresult { get; set; }
+        public string JsonPayload { get; set; }
     }
+        public class CircuitControl_Fields
+    {
+        public string CircuitStatus { get; set; }
+        public long HiResTimeStamp { get; set; }
+        public int Count { get; set; }
+        public int MaxAttempts { get; set; }
+        public int MaxConsecutive { get; set; }
+        public int MaxHalfRate { get; set; }
+        public int InactivityResetSeconds { get; set; }
+        public int HalfIntervalSeconds { get; set; }
+        public int TimeoutSeconds { get; set; }        
+   }
+public class TaskResultFields
+    {
+        public string Error { get; set; }
+        public string Cause { get; set; }
+    }            
 }

--- a/circuit-breaker/statemachine/circuitbreaker.asl.json
+++ b/circuit-breaker/statemachine/circuitbreaker.asl.json
@@ -2,68 +2,157 @@
   "StartAt": "Get Circuit Status",
   "States": {
     "Get Circuit Status": {
-      "Next": "Is Circuit Closed",
+      "Next": "Is Circuit Open?",
       "Type": "Task",
       "Comment": "Get Circuit Status",
-      "Resource": "${GetCircuitStatusFunctionArn}"
-    },
-    "Is Circuit Closed": {
-      "Type": "Choice",
-      "Choices": [
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultSelector": {
+        "CircuitStatus.$": "$.Payload.CircuitControl.CircuitStatus",
+        "HiResTimeStamp.$": "$.Payload.CircuitControl.HiResTimeStamp",
+        "Count.$": "$.Payload.CircuitControl.Count",
+        "MaxAttempts.$": "$.Payload.CircuitControl.MaxAttempts",
+        "MaxConsecutive.$": "$.Payload.CircuitControl.MaxConsecutive",
+        "MaxHalfRate.$": "$.Payload.CircuitControl.MaxHalfRate",
+        "HalfIntervalSeconds.$": "$.Payload.CircuitControl.HalfIntervalSeconds",
+        "InactivityResetSeconds.$": "$.Payload.CircuitControl.InactivityResetSeconds",
+        "TimeoutSeconds.$": "$.Payload.CircuitControl.TimeoutSeconds"
+      },
+      "ResultPath": "$.CircuitControl",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${GetCircuitStatusFunctionArn}"
+      },
+      "Retry": [
         {
-          "Variable": "$.CircuitStatus",
-          "StringEquals": "OPEN",
-          "Next": "Circuit Open"
-        },
-        {
-          "Variable": "$.CircuitStatus",
-          "StringEquals": "",
-          "Next": "Execute Lambda"
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
         }
       ]
     },
-    "Circuit Open": {
-      "Type": "Fail"
-    },
-    "Update Circuit Status": {
-      "Next": "Circuit Open",
-      "Type": "Task",
-      "Comment": "Update Circuit Status",
-      "Resource": "${UpdateCircuitStatusFunctionArn}"
-    },
-    "Execute Lambda": {
-      "Next": "Circuit Closed",
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "FunctionName.$": "$.TargetLambda"
-      },
-      "Comment": "Task to execute lambda. This will set circuit status to OPEN if the execution fails for three times or the task times out",
-      "TimeoutSeconds": 12,
-      "Retry": [
+    "Is Circuit Open?": {
+      "Type": "Choice",
+      "Choices": [
         {
-          "BackoffRate": 1.5,
-          "MaxAttempts": 3,
-          "IntervalSeconds": 2,
-          "ErrorEquals": [
-            "States.TaskFailed",
-            "States.Timeout"
-          ]
+          "Variable": "$.CircuitControl.CircuitStatus",
+          "StringEquals": "OPEN",
+          "Next": "Fail"
         }
       ],
+      "Default": "Execute Lambda"
+    },
+    "Fail": {
+      "Type": "Fail"
+    },
+    "Record Invoke Failure": {
+      "Next": "Try Limit Reached?",
+      "Type": "Task",
+      "Comment": "Update CallResult",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultSelector": {
+        "CircuitStatus.$": "$.Payload.CircuitControl.CircuitStatus",
+        "HiResTimeStamp.$": "$.Payload.CircuitControl.HiResTimeStamp",
+        "Count.$": "$.Payload.CircuitControl.Count",
+        "MaxAttempts.$": "$.Payload.CircuitControl.MaxAttempts",
+        "MaxConsecutive.$": "$.Payload.CircuitControl.MaxConsecutive",
+        "MaxHalfRate.$": "$.Payload.CircuitControl.MaxHalfRate",
+        "HalfIntervalSeconds.$": "$.Payload.CircuitControl.HalfIntervalSeconds",
+        "InactivityResetSeconds.$": "$.Payload.CircuitControl.InactivityResetSeconds",
+        "TimeoutSeconds.$": "$.Payload.CircuitControl.TimeoutSeconds"
+      },
+      "ResultPath": "$.CircuitControl",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${UpdateCircuitStatusFunctionArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ]
+    },    
+    "Try Limit Reached?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Or": [
+            {
+              "Variable": "$.CircuitControl.Count",
+              "IsPresent": false
+            },
+            {
+              "Variable": "$.CircuitControl.Count",
+              "NumericGreaterThanEqualsPath": "$.CircuitControl.MaxAttempts"
+            }
+          ],
+          "Next": "Fail"
+        }
+      ],
+      "Default": "Get Circuit Status"
+    },
+    "Execute Lambda": {
+      "Next": "Record Invoke Success",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName.$": "$.TargetLambda"
+      },
+      "Comment": "Task to execute lambda.",
+      "TimeoutSecondsPath": "$.CircuitControl.TimeoutSeconds",
       "Catch": [
         {
           "ErrorEquals": [
             "States.TaskFailed",
             "States.Timeout"
           ],
-          "Next": "Update Circuit Status",
+          "Next": "Record Invoke Failure",
           "ResultPath": "$.taskresult"
         }
       ]
     },
-    "Circuit Closed": {
-      "Type": "Succeed"
+    "Record Invoke Success": {
+      "Next": "Success",
+      "Type": "Task",
+      "Comment": "Update CallResult",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${UpdateCircuitStatusFunctionArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ]
+    },
+    "Success": {
+      "Type": "Succeed",
+      "OutputPath": "$.Payload"
     }
   }
 }

--- a/circuit-breaker/template.yaml
+++ b/circuit-breaker/template.yaml
@@ -1,22 +1,69 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  Sample SAM Template for circuit breaker pattern
+  SAM Template for circuit breaker pattern
 
 Resources:
+
+  CircuitBreakerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: 'SamCircuitBreaker-CircuitBreakerLogGroup'
+
   CircuitBreakerStateMachine:
     Type: AWS::Serverless::StateMachine # More info about State Machine Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
     Properties:
+      Type: STANDARD  # STANDARD or EXPRESS
       DefinitionUri: statemachine/circuitbreaker.asl.json
       DefinitionSubstitutions:
         GetCircuitStatusFunctionArn: !GetAtt GetCircuitStatusFunction.Arn
         UpdateCircuitStatusFunctionArn: !GetAtt UpdateCircuitStatusFunction.Arn
-        DDBPutItem: !Sub arn:${AWS::Partition}:states:::dynamodb:putItem
-        DDBTable: !Ref CircuitBreakerTable
-      Policies: # Find out more about SAM policy templates: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html
-        - AWSLambdaRole
-        - DynamoDBWritePolicy:
-            TableName: !Ref CircuitBreakerTable
+      Role: !GetAtt CircuitBreakerStateMachineRole.Arn
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt CircuitBreakerLogGroup.Arn
+        IncludeExecutionData: true
+        Level: 'ALL'
+      Tracing:
+        Enabled: true
+
+  #Execution Role for StepFunctions
+  CircuitBreakerStateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - states.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'cloudwatch:*'
+                  - 'logs:*'
+                Resource: '*'
+        - PolicyName: LambdaInvoke
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'lambda:InvokeFunction'
+                Resource: 
+                  - !GetAtt GetCircuitStatusFunction.Arn
+                  - !GetAtt UpdateCircuitStatusFunction.Arn
+                  # Include below the Lambda Function ARNs that are allowed as a TargetLambda                  
+                  - !GetAtt TestCircuitBreakerFunction.Arn
+                  - !GetAtt HelloWorldFunction.Arn
 
   GetCircuitStatusFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -24,14 +71,15 @@ Resources:
       CodeUri: ./GetCircuitStatusLambda/src/GetCircuitStatusLambda/
       Handler: GetCircuitStatusLambda::GetCircuitStatusLambda.GetCircuitStatus::FunctionHandler
       Runtime: dotnet6
+      Architectures:
+        - x86_64
       MemorySize: 256
       Timeout: 30
       Policies:
-        - AmazonDynamoDBFullAccess
-        - CloudWatchLogsFullAccess
-        - AWSXrayFullAccess
-        - AWSStepFunctionsFullAccess
-
+        - DynamoDBCrudPolicy:
+            TableName:
+             !Ref CircuitBreakerTable
+      Tracing: Active
 
   UpdateCircuitStatusFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -39,13 +87,15 @@ Resources:
       CodeUri: ./UpdateCircuitStatusLambda/src/UpdateCircuitStatusLambda/
       Handler: UpdateCircuitStatusLambda::UpdateCircuitStatusLambda.UpdateCircuitStatus::FunctionHandler
       Runtime: dotnet6
+      Architectures:
+        - x86_64
       MemorySize: 256
       Timeout: 30
       Policies:
-        - AmazonDynamoDBFullAccess
-        - CloudWatchLogsFullAccess
-        - AWSXrayFullAccess
-        - AWSStepFunctionsFullAccess      
+        - DynamoDBCrudPolicy:
+            TableName:
+             !Ref CircuitBreakerTable
+      Tracing: Active
 
   TestCircuitBreakerFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -53,13 +103,11 @@ Resources:
       CodeUri: ./TestCircuitBreaker/src/TestCircuitBreaker/
       Handler: TestCircuitBreaker::TestCircuitBreaker.Function::FunctionHandler
       Runtime: dotnet6
+      Architectures:
+        - x86_64
       MemorySize: 256
       Timeout: 30
-      Policies:
-        - AmazonDynamoDBFullAccess
-        - CloudWatchLogsFullAccess
-        - AWSXrayFullAccess
-        - AWSStepFunctionsFullAccess
+      Tracing: Active
   
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -67,29 +115,26 @@ Resources:
       CodeUri: ./HelloWorld/src/HelloWorld/
       Handler: HelloWorld::HelloWorld.Function::FunctionHandler
       Runtime: dotnet6
+      Architectures:
+        - x86_64
       MemorySize: 256
       Timeout: 30
-      Policies:
-        - AmazonDynamoDBFullAccess
-        - CloudWatchLogsFullAccess
-        - AWSXrayFullAccess
-        - AWSStepFunctionsFullAccess
-
+      Tracing: Active
 
   CircuitBreakerTable:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: CircuitBreaker
-      KeySchema:
-        - AttributeName: ServiceName
-          KeyType: HASH
-        - AttributeName: ExpireTimeStamp
-          KeyType: RANGE
       AttributeDefinitions:
         - AttributeName: ServiceName
           AttributeType: S
-        - AttributeName: ExpireTimeStamp
+        - AttributeName: HiResTimeStamp
           AttributeType: N
+      KeySchema:
+        - AttributeName: ServiceName
+          KeyType: HASH
+        - AttributeName: HiResTimeStamp
+          KeyType: RANGE
       ProvisionedThroughput:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5

--- a/circuitbreaker-dashboard/.gitignore
+++ b/circuitbreaker-dashboard/.gitignore
@@ -1,0 +1,9 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+package-lock.json
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/circuitbreaker-dashboard/bin/circuitbreaker-dashboard.ts
+++ b/circuitbreaker-dashboard/bin/circuitbreaker-dashboard.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { CircuitbreakerDashboardStack } from '../lib/circuitbreaker-dashboard-stack';
+import { CloudFormationHelper } from '../lib/helper/cloudformation-parser';
+
+(async () => {
+    const app = new cdk.App();
+    const monitoringStackName = app.node.tryGetContext('stack_name')
+    if (!monitoringStackName) {
+        console.log("****************************************************");
+        console.log("ERROR: your AWS SAM backend CloudFormation stack_name is undefined.\n");
+        console.log("Please run the command like this:");
+        console.log("cdk [synth|deploy|destroy] -c stack_name=<your SAM stack name>");
+        console.log("****************************************************");
+        process.exit(1);
+    }
+    const functions = await new CloudFormationHelper().cfn_parser(monitoringStackName)
+    new CircuitbreakerDashboardStack(app, 'CircuitbreakerDashboardStack', { functions: functions });
+})()

--- a/circuitbreaker-dashboard/cdk.json
+++ b/circuitbreaker-dashboard/cdk.json
@@ -1,0 +1,44 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/circuitbreaker-dashboard.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false
+  }
+}

--- a/circuitbreaker-dashboard/jest.config.js
+++ b/circuitbreaker-dashboard/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/circuitbreaker-dashboard/lib/circuitbreaker-dashboard-stack.ts
+++ b/circuitbreaker-dashboard/lib/circuitbreaker-dashboard-stack.ts
@@ -1,0 +1,119 @@
+/**************************************************************************************************
+Legal Disclaimer: The sample code; software libraries; command line tools; proofs of concept;
+templates; or other related technology (including any of the foregoing that are provided by our
+personnel) is provided to you as AWS Content under the AWS Customer Agreement, or the relevant
+written agreement between you and AWS (whichever applies). You should not use this AWS Content in
+your production accounts, or on production or other critical data. You are responsible for testing,
+securing, and optimizing the AWS Content, such as sample code, as appropriate for production grade
+use based on your specific quality control practices and standards. Deploying AWS Content may incur
+AWS charges for creating or using AWS chargeable resources, such as running Amazon EC2 instances or
+using Amazon S3 storage.
+**************************************************************************************************/
+
+import * as cdk from 'aws-cdk-lib';
+import { aws_cloudwatch as cloudwatch } from 'aws-cdk-lib';
+import { GraphWidget, Metric, DimensionHash } from 'aws-cdk-lib/aws-cloudwatch'
+
+export interface MyStackProps extends cdk.StackProps {
+  functions?: any;
+}
+
+export class CircuitbreakerDashboardStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props: MyStackProps = {}) {
+    super(scope, id, props);
+
+    const CircuitBreakerDashboard = new cloudwatch.Dashboard(this, 'CircuitBreaker-Dashboard', { dashboardName: 'CircuitBreaker-Dashboard' })
+    CircuitBreakerDashboard.addWidgets(
+      this.buildAllGraphWidget('All Target Lambda Functions', props.functions),
+      this.buildClosedGraphWidget('Circuit Breaker CLOSED', props.functions),
+      this.buildHalfGraphWidget('Circuit Breaker HALF', props.functions),
+      this.buildOpenGraphWidget('Circuit Breaker OPEN', props.functions),
+      this.buildTargetLambdaGraphWidget('Status for ' + props.functions.TestCircuitBreakerFunction, props.functions.GetCircuitStatusFunction, props.functions.TestCircuitBreakerFunction),
+      this.buildTargetLambdaGraphWidget('Status for ' + props.functions.HelloWorldFunction, props.functions.GetCircuitStatusFunction, props.functions.HelloWorldFunction)
+    );
+  }
+
+  // Example with Graph Widget
+  buildAllGraphWidget(widgetName: string, functions: any = {}): GraphWidget {
+    return new GraphWidget({
+      title: widgetName,
+      height: 7,
+      width: 6,
+      left: [
+        this.buildMetric('CircuitBreaker', 'CLOSED', 'CircuitStatus', 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'CLOSED' }),
+        this.buildMetric('CircuitBreaker', 'HALF', 'CircuitStatus', 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'HALF' }),
+        this.buildMetric('CircuitBreaker', 'OPEN', 'CircuitStatus', 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'OPEN' })
+      ],
+      stacked: true,
+      liveData: true
+    })
+  }
+
+  // Example with Graph Widget
+  buildClosedGraphWidget(widgetName: string, functions: any = {}): GraphWidget {
+    return new GraphWidget({
+      title: widgetName,
+      height: 7,
+      width: 6,
+      left: [
+        this.buildMetric('CircuitBreaker', 'CLOSED', 'CircuitStatus', 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'CLOSED' })
+      ],
+      stacked: true,
+      liveData: true
+    })
+  }
+
+  buildHalfGraphWidget(widgetName: string, functions: any = {}): GraphWidget {
+    return new GraphWidget({
+      title: widgetName,
+      height: 7,
+      width: 6,
+      left: [
+        this.buildMetric('CircuitBreaker', 'HALF', 'CircuitStatus', 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'HALF' })
+      ],
+      stacked: true,
+      liveData: true
+    })
+  }
+
+  // Example with Graph Widget
+  buildOpenGraphWidget(widgetName: string, functions: any = {}): GraphWidget {
+    return new GraphWidget({
+      title: widgetName,
+      height: 7,
+      width: 6,
+      left: [
+        this.buildMetric('CircuitBreaker', 'OPEN', 'CircuitStatus', 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'OPEN' })
+      ],
+      stacked: true,
+      liveData: true
+    })
+  }
+  
+ // Example with Graph Widget
+  buildTargetLambdaGraphWidget(widgetName: string, serviceName: string = '', targetLambda: string = ''): GraphWidget {
+    return new GraphWidget({
+      title: widgetName,
+      height: 7,
+      width: 12,
+      left: [
+        this.buildMetric('CircuitBreaker', 'CLOSED', serviceName, 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'CLOSED', ServiceType: 'AWS::Lambda::Function', ServiceName: serviceName, TargetLambda: targetLambda}),
+        this.buildMetric('CircuitBreaker', 'HALF', serviceName, 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'HALF', ServiceType: 'AWS::Lambda::Function', ServiceName: serviceName, TargetLambda: targetLambda}),
+        this.buildMetric('CircuitBreaker', 'OPEN', serviceName, 'CircuitBreakerUsage', 'sum', cdk.Duration.minutes(5), {  CircuitStatus: 'OPEN', ServiceType: 'AWS::Lambda::Function', ServiceName: serviceName, TargetLambda: targetLambda})
+      ],
+      stacked: true,
+      liveData: true
+    })
+  }
+
+  buildMetric(namespace: string, label: string, functionName: string, metricName: string, statistic: string, period: any, dimensions: DimensionHash): Metric {
+    return new Metric({
+      namespace: namespace,
+      metricName: metricName,
+      period: period,
+      dimensionsMap: dimensions,
+      label: label,
+      statistic: statistic
+    })
+  }
+}

--- a/circuitbreaker-dashboard/lib/helper/cloudformation-parser.ts
+++ b/circuitbreaker-dashboard/lib/helper/cloudformation-parser.ts
@@ -1,0 +1,39 @@
+/**************************************************************************************************
+Legal Disclaimer: The sample code; software libraries; command line tools; proofs of concept;
+templates; or other related technology (including any of the foregoing that are provided by our
+personnel) is provided to you as AWS Content under the AWS Customer Agreement, or the relevant
+written agreement between you and AWS (whichever applies). You should not use this AWS Content in
+your production accounts, or on production or other critical data. You are responsible for testing,
+securing, and optimizing the AWS Content, such as sample code, as appropriate for production grade
+use based on your specific quality control practices and standards. Deploying AWS Content may incur
+AWS charges for creating or using AWS chargeable resources, such as running Amazon EC2 instances or
+using Amazon S3 storage.
+**************************************************************************************************/
+
+import { CloudFormation } from "@aws-sdk/client-cloudformation";
+
+export class CloudFormationHelper {
+    cfn_parser = async (stack_name: string = '') => {
+        let functions: any = {}
+        try {
+          const cfn = new CloudFormation({ region: process.env["DEPLOY_REGION"]?.toString().toLocaleLowerCase() })
+            const data = await cfn.describeStackResources({ StackName: stack_name })
+            if (data.StackResources) {
+                data.StackResources.forEach(resource => {
+                    // Use of "startsWith" instead of "==="" is to support both SAM and CDK
+                    if (resource.ResourceType === "AWS::Lambda::Function")
+                    {
+                        if (resource.LogicalResourceId?.startsWith("GetCircuitStatusFunction")) functions.GetCircuitStatusFunction = resource.PhysicalResourceId
+                        if (resource.LogicalResourceId?.startsWith('TestCircuitBreakerFunction')) functions.TestCircuitBreakerFunction = resource.PhysicalResourceId
+                        if (resource.LogicalResourceId?.startsWith('HelloWorldFunction')) functions.HelloWorldFunction = resource.PhysicalResourceId    
+                    }
+
+                });
+            }
+        }
+        catch (err) {
+            throw new Error("Unable to access your AWS SAM backend CloudFormation stack_name: " + stack_name + "; " + String(err))
+        }
+        return functions
+    }
+}

--- a/circuitbreaker-dashboard/package.json
+++ b/circuitbreaker-dashboard/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "circuitbreaker-dashboard",
+  "version": "0.1.0",
+  "bin": {
+    "circuitbreaker-dashboard": "bin/circuitbreaker-dashboard.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.1",
+    "@types/node": "20.1.7",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "aws-cdk": "2.81.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.0.4"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.81.0",
+    "@aws-sdk/client-cloudformation": "^3.267.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/circuitbreaker-dashboard/test/circuitbreaker-dashboard.test.ts
+++ b/circuitbreaker-dashboard/test/circuitbreaker-dashboard.test.ts
@@ -1,0 +1,14 @@
+import { expect as expectCDK, matchTemplate, MatchStyle } from '@aws-cdk/assert';
+import * as cdk from 'aws-cdk-lib';
+//import { Template } from 'aws-cdk-lib/assertions';
+import * as CircuitbreakerDashboard from '../lib/circuitbreaker-dashboard-stack';
+
+test('Empty Stack', () => {
+    const app = new cdk.App();
+    // WHEN
+    const stack = new CircuitbreakerDashboard.CircuitbreakerDashboardStack(app, 'MyTestStack');
+    // THEN
+    expectCDK(stack).to(matchTemplate({
+      "Resources": {}
+    }, MatchStyle.EXACT))
+});

--- a/circuitbreaker-dashboard/tsconfig.json
+++ b/circuitbreaker-dashboard/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
subset of the requests.  Also provided behavior customization using JSON parameters. Lastly, added IaC to build a CloudWatch dashboard to provide observability.

*Issue #, if available:*

*Description of changes:*
Status based on results of most-recent calls recorded in DynamoDB Table
  • CLOSED –No/limited consecutive failures; call allowed
  • HALF – Consecutive failures occurred; Call allowed to check status
  • OPEN – Call denied after Consecutive failures; No record added to table
• Parameterized to allow per-service tuning
• State timeout tunable using parameter
• UpdateCircuitStatus Lambda updates DynamoDB Table with Fail (2) if taskresult.Error is not empty; otherwise Success (1)
• Record located using ServiceName and HiResTimeStamp (Unix mSec) provided by GetCircuitStatus
• Try Limit tunable using parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
